### PR TITLE
#167511622 make sure the loader disappears on error

### DIFF
--- a/src/components/auth/login/loginContainer.jsx
+++ b/src/components/auth/login/loginContainer.jsx
@@ -39,6 +39,7 @@ export class LoginContainer extends React.Component {
 
     await loginAction(loginInfo);
 
+    this.setState({ isLoading: false });
     this.handleClearForm();
   }
 


### PR DESCRIPTION
#### What does this PR do?
Intends to fix the login loader

#### Description of Task to be completed?
When a user enters the wrong credentials, the loader would still run even after the error toast message is long gone. This PR solves the small bug.

#### How should this be manually tested?
Follow the setup steps on the [readme page](https://github.com/andela/ah-frontend-kronos) of this repo, then follow the login link on the navbar.

#### Any background context you want to provide?
This bug was introduced when login files were changed from merging the previous PR.

#### What are the relevant pivotal tracker stories?
[#167511622](https://www.pivotaltracker.com/story/show/167511622)