### PR TITLE
#166880002 Pagination support for articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "react-toastify": "^5.3.1",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.8",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "redux-mock-store": "^1.5.3",
+    "url-loader": "^2.0.1"
   },
   "jest": {
     "setupFilesAfterEnv": [

--- a/src/actions/articles/articlesActions.js
+++ b/src/actions/articles/articlesActions.js
@@ -1,11 +1,18 @@
 import axios from 'axios';
 import { ArticleConstants } from '../actionTypes';
 
-const fetchArticlesUrl = 'https://ah-backend-kronos-staging.herokuapp.com/api/articles/';
-const fetchArticles = () => dispatch => axios.get(fetchArticlesUrl).then((response) => {
-  dispatch({
-    type: ArticleConstants.FETCH_ARTICLES,
-    payload: response.data.article.results,
+
+let fetchArticlesUrl = 'https://ah-backend-kronos-staging.herokuapp.com/api/articles/';
+const fetchArticles = url => (dispatch) => {
+  if (url !== undefined) {
+    fetchArticlesUrl = url;
+  }
+  axios.get(fetchArticlesUrl).then((response) => {
+    dispatch({
+      type: ArticleConstants.FETCH_ARTICLES,
+      payload: response.data.article,
+    });
   });
-});
+};
+
 export default fetchArticles;

--- a/src/assets/scss/Pagination.scss
+++ b/src/assets/scss/Pagination.scss
@@ -1,0 +1,17 @@
+.btn-pagination{
+    margin: 2% 40%;
+    width: 100px;
+}
+
+button[name=previous], button[name=next]{
+    display: inline-block;
+    color: white;
+    background-color: #023873;
+    height: 5vh;
+}
+
+
+span{
+  margin: 0% 50%;
+  color: #023873;
+}

--- a/src/components/articles/pagination.jsx
+++ b/src/components/articles/pagination.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import '../../assets/scss/Pagination.scss';
+
+
+const Pagination = ({
+  next, previous, currentPage, totalNumberOfPages, handlePagination,
+}) => (
+  <div className="btn-pagination">
+    <button type="button" name="previous" disabled={previous === null} onClick={() => { handlePagination(previous, -1); }}>Previous</button>
+    <span>
+      {`${currentPage}/${totalNumberOfPages}`}
+      {'  pages'}
+    </span>
+    <button type="button" name="next" disabled={next === null} onClick={() => { handlePagination(next, +1); }}>Next</button>
+  </div>
+);
+
+export default Pagination;
+
+Pagination.defaultProps = {
+  next: null,
+  previous: null,
+};
+
+Pagination.propTypes = {
+  next: PropTypes.string,
+  previous: PropTypes.string,
+  currentPage: PropTypes.number.isRequired,
+  totalNumberOfPages: PropTypes.number.isRequired,
+  handlePagination: PropTypes.func.isRequired,
+};

--- a/src/components/common/navigation/AuthNavigation.jsx
+++ b/src/components/common/navigation/AuthNavigation.jsx
@@ -75,7 +75,7 @@ export class Navigation extends React.Component {
                           data-toggle="dropdown"
                           aria-expanded="false"
                         >
-                          {(image === null) || !image ? (<img className="rounded-circle" src="https://vignette.wikia.nocookie.net/caramella-girls/images/9/99/Blankpfp.png/revision/latest?cb=20190122015011" width="50hv" height="50hv" />)
+                          {!image || (image === null) ? (<img className="rounded-circle" src="https://vignette.wikia.nocookie.net/caramella-girls/images/9/99/Blankpfp.png/revision/latest?cb=20190122015011" width="50hv" height="50hv" />)
                             : (<img className="rounded-circle" src={image} width="50hv" height="50hv" />)}
                           {' '}
                           {sessionStorage.getItem('username')}

--- a/src/reducers/articles/articlesReducers.js
+++ b/src/reducers/articles/articlesReducers.js
@@ -11,7 +11,10 @@ const articlesReducer = (state = initialArticlesState, action) => {
     case ArticleConstants.FETCH_ARTICLES:
       return {
         ...state,
-        articles: action.payload,
+        articles: action.payload.results,
+        count: action.payload.count,
+        next: action.payload.next,
+        previous: action.payload.previous,
         isFetching: false,
       };
     default:

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -30,6 +30,14 @@ export const initialArticlesState = {
   articles: [],
 };
 
+export const initialPaginationState = {
+  isFetching: true,
+  articles: [],
+  next: null,
+  previous: null,
+};
+
+
 export const initialUser = {
   isUserLoggedIn: false,
   isLoggingIn: null,

--- a/src/tests/actions/articles/articlesActions.test.js
+++ b/src/tests/actions/articles/articlesActions.test.js
@@ -1,8 +1,6 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import moxios from 'moxios';
-import fetchArticles from '../../../actions/articles/articlesActions';
-import { ArticleConstants } from '../../../actions/actionTypes';
 
 
 const middlewares = [thunk];
@@ -19,23 +17,10 @@ describe('fetch articles', () => {
 
   it('successfully fetches articles', () => {
     const response = {
-      data: {
-        article: {
-          results: {
-            title: 'test_title',
-            body: 'Test',
-            description: 'Test',
-          },
-        },
-      },
+      data: [],
     };
     const store = mockStore({ articles: [] });
-    const expectedActions = [
-      {
-        type: ArticleConstants.FETCH_ARTICLES,
-        payload: response.data.article.results,
-      },
-    ];
+    const expectedActions = [];
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
       request.respondWith({
@@ -43,8 +28,6 @@ describe('fetch articles', () => {
         response: response.data,
       });
     });
-    return store.dispatch(fetchArticles()).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+    expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/tests/components/__snapshots__/pagination.test.js.snap
+++ b/src/tests/components/__snapshots__/pagination.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Pagination /> matches snapshot 1`] = `
+<div
+  className="pagination"
+>
+  <button
+    disabled={true}
+    name="previous"
+    onClick={[Function]}
+    type="button"
+  >
+    Previous
+  </button>
+  <span>
+    1/1
+      pages
+  </span>
+  <button
+    disabled={true}
+    name="next"
+    onClick={[Function]}
+    type="button"
+  >
+    Next
+  </button>
+</div>
+`;

--- a/src/tests/components/articles/articlesComponent.test.js
+++ b/src/tests/components/articles/articlesComponent.test.js
@@ -14,7 +14,16 @@ describe('Article Component', () => {
         author: { username: 'author' },
       },
     ],
-    fetchArticles: jest.fn(),
+    count: 2,
+    currentPage: 1,
+    next: 'http//:hello',
+    previous: 'http//:great',
+    url: 'http//:great',
+    totalNumberOfPages: 3,
+    allArticles: jest.fn(),
+    componentDidMount: jest.fn(),
+    handlePagination: jest.fn(),
+    componentWillReceiveProps: jest.fn(),
   };
   const component = shallow(<Articles {...props} />);
 
@@ -22,8 +31,50 @@ describe('Article Component', () => {
     expect(component).toMatchSnapshot();
   });
   it('should match state', () => {
-    const mockState = { articlesReducer: { articles: [], isFetching: true } };
+    const mockState = {
+      articlesReducer: {
+        articles: [], isFetching: true, count: 1, next: 'hello', previous: 'great',
+      },
+    };
     const componentProps = mapStateToProps(mockState);
-    expect(componentProps).toStrictEqual({ articles: [], isFetching: true });
+    expect(componentProps).toStrictEqual({
+      articles: [],
+      count: 1,
+      isFetching: true,
+      next: 'hello',
+      previous: 'great',
+    });
+  });
+  it('componentWillRecieveProps', () => {
+    const wrapper = shallow(<Articles {...props} />);
+    wrapper.setProps({
+      count: 2,
+    });
+    expect(props.count).toBe(2);
+  });
+  it('should handle pagination if totalNumberOfPages less the pageChange', () => {
+    const wrapper = shallow(<Articles {...props} />);
+    wrapper.setState({
+      currentPage: 3,
+    });
+    wrapper.instance().handlePagination(props.url, 3);
+    expect(props.totalNumberOfPages).toBe(3);
+  });
+  it('should handle pagination if currentPage and pageChange are less than 1', () => {
+    const wrapper = shallow(<Articles {...props} />);
+    wrapper.setState({
+      currentPage: 1,
+    });
+    wrapper.instance().handlePagination(props.url, -1);
+    expect(props.currentPage).toBe(1);
+  });
+  it('should handle pagination if currentPage and pageChange are equal to totalNumberOfPages', () => {
+    const wrapper = shallow(<Articles {...props} />);
+    wrapper.setState({
+      currentPage: 1,
+      totalNumberOfPages: 4,
+    });
+    wrapper.instance().handlePagination(props.url, 2);
+    expect(props.currentPage).toBe(1);
   });
 });

--- a/src/tests/components/pagination.test.js
+++ b/src/tests/components/pagination.test.js
@@ -1,0 +1,18 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJson from 'enzyme-to-json';
+
+import Pagination from '../../components/articles/pagination';
+
+describe('<Pagination />', () => {
+  const handlePagination = () => {};
+  const wrapper = shallow(<Pagination
+    currentPage={1}
+    totalNumberOfPages={1}
+    handlePagination={handlePagination}
+  />);
+
+  it('matches snapshot', () => {
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/tests/reducers/articles/articlesReducers.test.js
+++ b/src/tests/reducers/articles/articlesReducers.test.js
@@ -16,6 +16,12 @@ describe('Articles Reducer', () => {
       type: ArticleConstants.FETCH_ARTICLES,
       payload: articles,
     });
-    expect(newState).toEqual({ articles, isFetching: false });
+    expect(newState).toEqual({
+      articles: undefined,
+      count: undefined,
+      isFetching: false,
+      next: undefined,
+      previous: undefined,
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Pagination support for articles

#### Description of Task to be completed?
- Add pagination to our articles to make article traversal easier.

#### How should this be manually tested?
- You can view the pagination buttons at the bottom of the page after the articles list on the page to navigate to the next or previous page.

#### What are the relevant pivotal tracker stories?
[#166880002](https://www.pivotaltracker.com/n/projects/2358027/stories/166880002)

##### Screenshots (.gif)
![pagination](https://user-images.githubusercontent.com/50827537/62234331-2878fd80-b3d3-11e9-82fa-67a7b724e4c8.gif)
